### PR TITLE
update Google Play Store link

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -363,7 +363,7 @@
                 <!--    buttons show on mobile-->
                 <div class="d-flex d-lg-none flex-md-row mobile-btns">
                     <!--google btn-->
-                    <a href="https://play.google.com/apps/testing/com.breez.client" target="_blank" role="button"
+                    <a href="https://play.google.com/store/apps/details?id=com.breez.client" target="_blank" role="button"
                         class="download-btn--android text-decoration-none mb-2 mb-md-0 me-3 me-md-4">
                         <img src="assets/icons/google-play-btn.svg" alt="google play button" class="google-btn">
                     </a>
@@ -389,7 +389,7 @@
             <!--    buttons show on desktop-->
             <div class="d-none d-lg-flex flex-column flex-md-row">
                 <!--google btn-->
-                <a href="https://play.google.com/apps/testing/com.breez.client" target="_blank" role="button"
+                <a href="https://play.google.com/store/apps/details?id=com.breez.client" target="_blank" role="button"
                     class="text-decoration-none mb-2 mb-md-0 me-0 me-md-4">
                     <img src="assets/icons/google-play-btn.svg" alt="google play button" class="google-btn">
                 </a>

--- a/src/views/pages/mobile/mobile.html
+++ b/src/views/pages/mobile/mobile.html
@@ -124,7 +124,7 @@
                 <!--    buttons show on desktop-->
                 <div class="d-flex mobile-btns">
                     <!--google btn-->
-                    <a href="https://play.google.com/apps/testing/com.breez.client" target="_blank" role="button"
+                    <a href="https://play.google.com/store/apps/details?id=com.breez.client" target="_blank" role="button"
                         class="download-btn--android text-decoration-none mb-2 mb-md-0 me-3 me-md-4">
                         <img src="../../../assets/icons/google-play-btn.svg" alt="google play button"
                             class="google-btn">

--- a/static/open-in-mobile.html
+++ b/static/open-in-mobile.html
@@ -113,7 +113,7 @@
                     <span class="badge-btn__text">Download on the</span>
                     <span class="badge-btn__storename">App Store</span>
                   </a>
-                  <a class="badge-btn badge-btn--android" href="https://play.google.com/apps/testing/com.breez.client"
+                  <a class="badge-btn badge-btn--android" href="https://play.google.com/store/apps/details?id=com.breez.client"
                     target="_blank" rel="noopener noreferrer">
                     <svg class="badge-btn__icon badge-btn__icon--google" version="1.1"
                       xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"


### PR DESCRIPTION
current link requires/prompts google account login, 
new link leads to the right page, so it also works with google play store alternatives like aurora store